### PR TITLE
Disable Publish Release Candidate CI step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -360,7 +360,7 @@ jobs:
   docker-build-image-for-churchbulletin-ui:
     name: Publish Release Candidate
     needs: [build-linux]
-    if: success() 
+    if: false # Disabled - Azure credentials not configured
     runs-on: ubuntu-latest
     concurrency:
       # Stop publishing a release candidate if a newer job arrives.


### PR DESCRIPTION
## Summary
- Disables the "Publish Release Candidate" job in the CI workflow (`build.yml`) by setting `if: false`
- This job consistently fails because Azure credentials (`client-id`, `tenant-id`) are not configured for this repository
- The failure is infrastructure-related, not code-related, and blocks CI from going fully green
- All other CI checks (Security Scan, Code Analysis, Integration Builds, Acceptance Tests, Publish to GitHub Packages, Publish to Octopus Deploy) are unaffected