### PR TITLE
Enable AutoReformatAgentService

### DIFF
--- a/src/UI/Server/appsettings.json
+++ b/src/UI/Server/appsettings.json
@@ -12,5 +12,5 @@
   "AI_OpenAI_ApiKey": "",
   "AI_OpenAI_Url": "",
   "AI_OpenAI_Model": "",
-  "DISABLE_AUTO_REFORMAT_AGENT": "true"
+  "DISABLE_AUTO_REFORMAT_AGENT": "false"
 }


### PR DESCRIPTION
## Summary
- Set `DISABLE_AUTO_REFORMAT_AGENT` to `"false"` in `src/UI/Server/appsettings.json` to enable the AutoReformatAgentService.

Fixes #15